### PR TITLE
Harden route security for projects, comments, and media

### DIFF
--- a/backend/src/routes/comments.ts
+++ b/backend/src/routes/comments.ts
@@ -6,6 +6,8 @@ import { authenticate } from "../auth.js";
 
 const router = express.Router();
 
+router.use(authenticate);
+
 router.get(
   "/node/:nodeId",
   asyncHandler(async (req, res) => {
@@ -17,13 +19,11 @@ router.get(
 router.post(
   "/node/:nodeId",
   asyncHandler(async (req, res) => {
-    const { reviewerName, text, userId } = req.body;
-    const comment = await prisma.reviewerComment.create({ data: { storyNodeId: req.params.nodeId, reviewerName, text, userId } });
+    const { reviewerName, text } = req.body;
+    const comment = await prisma.reviewerComment.create({ data: { storyNodeId: req.params.nodeId, reviewerName, text, userId: req.user!.id } });
     res.status(201).json(comment);
   })
 );
-
-router.use(authenticate);
 
 router.delete(
   "/:commentId",

--- a/backend/src/routes/media.ts
+++ b/backend/src/routes/media.ts
@@ -72,9 +72,16 @@ router.get(
 router.get(
   "/file/:filename",
   asyncHandler(async (req, res) => {
-    const filePath = path.join("..", "media", req.params.filename);
-    if (!fs.existsSync(filePath)) return res.status(404).end();
-    res.sendFile(path.resolve(filePath));
+    const mediaDir = path.resolve("..", "media");
+    const requestedPath = path.resolve(mediaDir, req.params.filename);
+
+    const isInsideMediaDir = requestedPath === mediaDir || requestedPath.startsWith(`${mediaDir}${path.sep}`);
+    if (!isInsideMediaDir || path.isAbsolute(req.params.filename) || req.params.filename.includes("..")) {
+      return res.status(400).json({ message: "Invalid filename" });
+    }
+
+    if (!fs.existsSync(requestedPath)) return res.status(404).end();
+    res.sendFile(requestedPath);
   })
 );
 

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -32,14 +32,38 @@ router.put(
   "/:id",
   asyncHandler(async (req, res) => {
     const { name, description } = req.body;
-    const project = await prisma.project.update({ where: { id: req.params.id }, data: { name, description } });
-    res.json(project);
+    const project = await prisma.project.findUnique({
+      where: { id: req.params.id },
+      include: { members: { select: { id: true } } }
+    });
+
+    if (!project) return res.status(404).json({ message: "Project not found" });
+
+    const isOwner = project.ownerId === req.user!.id;
+    const isMember = project.members.some((member) => member.id === req.user!.id);
+
+    if (!isOwner && !isMember) return res.status(403).json({ message: "Forbidden" });
+
+    const updatedProject = await prisma.project.update({ where: { id: req.params.id }, data: { name, description } });
+    res.json(updatedProject);
   })
 );
 
 router.delete(
   "/:id",
   asyncHandler(async (req, res) => {
+    const project = await prisma.project.findUnique({
+      where: { id: req.params.id },
+      include: { members: { select: { id: true } } }
+    });
+
+    if (!project) return res.status(404).json({ message: "Project not found" });
+
+    const isOwner = project.ownerId === req.user!.id;
+    const isMember = project.members.some((member) => member.id === req.user!.id);
+
+    if (!isOwner && !isMember) return res.status(403).json({ message: "Forbidden" });
+
     await prisma.project.delete({ where: { id: req.params.id } });
     res.status(204).end();
   })


### PR DESCRIPTION
## Summary
- enforce ownership or membership checks before updating or deleting projects
- require authentication for comment retrieval/creation and derive comment ownership from the authenticated user
- validate media download filenames to block traversal outside the media directory

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692361535bf0832ab8f0a901ed17c9c6)